### PR TITLE
ALBS-891 Fix prefix for websocket

### DIFF
--- a/sign_node/signer.py
+++ b/sign_node/signer.py
@@ -94,7 +94,7 @@ class Signer(object):
                 queue = websocket.WebSocketApp(
                     urllib.parse.urljoin(
                         self.__config.ws_master_url,
-                        'sign_task_queue/'
+                        'sign-tasks/sign_task_queue/'
                     ),
                     on_message=self.on_sync_request,
                     header={


### PR DESCRIPTION
In newer FastAPI releases they’ve fixed prefix settings to the Websocket routes, so we’ll need to update our Websocket route for signing files to save its current path.
Links https://github.com/AlmaLinux/albs-web-server/pull/400 