### PR TITLE
AlmaLinux/build-system#57: Mount the sources to a container (albs-web-server, albs-sign-node) instead store them into a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ WORKDIR /sign-node
 COPY requirements.txt /sign-node/requirements.txt
 
 RUN python3 -m venv --system-site-packages env
-RUN /sign-node/env/bin/pip install --upgrade pip==21.1 && /sign-node/env/bin/pip install -r requirements.txt && /sign-node/env/bin/pip cache purge
+RUN cd /sign-node && source /sign-node/env/bin/activate && pip3 install --upgrade pip && pip3 install -r /sign-node/requirements.txt --no-cache-dir
 
 RUN chown -R alt:alt /sign-node /wait_for_it.sh /srv
 USER alt
 
-CMD ["/sign-node/env/bin/python", "/sign-node/almalinux_sign_node.py"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_sign_node.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /sign-node
 COPY requirements.txt /sign-node/requirements.txt
 
 RUN python3 -m venv --system-site-packages env
-RUN cd /sign-node && source /sign-node/env/bin/activate && pip3 install --upgrade pip && pip3 install -r /sign-node/requirements.txt --no-cache-dir
+RUN cd /sign-node && source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir
 
 RUN chown -R alt:alt /sign-node /wait_for_it.sh /srv
 USER alt

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ COPY requirements.txt /sign-node/requirements.txt
 RUN python3 -m venv --system-site-packages env
 RUN /sign-node/env/bin/pip install --upgrade pip==21.1 && /sign-node/env/bin/pip install -r requirements.txt && /sign-node/env/bin/pip cache purge
 
-COPY ./sign_node /sign-node/sign_node
-COPY almalinux_sign_node.py /sign-node/almalinux_sign_node.py
-
 RUN chown -R alt:alt /sign-node /wait_for_it.sh /srv
 USER alt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       - "./node-config:/root/.config"
       - "./almalinux_sign_node.py:/sign-node/almalinux_sign_node.py"
       - "./sign_node:/sign-node/sign_node"
+      - "./requirements.txt:/sign-node/requirements.txt"
     extra_hosts:
      - "beta-build.cloudlinux.com:192.168.246.79"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,13 @@
 version: "3.9"
 services:
   sign_node:
-    image: avoid/alss-node
+    image: quay.io/almalinuxorg/albs-sign-node:latest
     privileged: true
-    build:
-      dockerfile: Dockerfile
-      context: .
     command: "bash -c 'source env/bin/activate && ./almalinux_sign_node.py -v'"
     restart: on-failure
     volumes:
       - "./node-config:/root/.config"
+      - "./almalinux_sign_node.py:/sign-node/almalinux_sign_node.py"
+      - "./sign_node:/sign-node/sign_node"
     extra_hosts:
      - "beta-build.cloudlinux.com:192.168.246.79"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   sign_node:
     image: quay.io/almalinuxorg/albs-sign-node:latest
     privileged: true
-    command: "bash -c 'source env/bin/activate && ./almalinux_sign_node.py -v'"
+    command: "bash -c 'source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_sign_node.py -v'"
     restart: on-failure
     volumes:
       - "./node-config:/root/.config"


### PR DESCRIPTION
- Mount requirements.txt into a container
- Run update of pip and install from requirements.txt before run an executable item in a container
- Copying the code into the images is removed
- Mount the sources to a container
- Pull the already built image from quay.io