### PR TITLE
Rename BuildSystem repository in signnode.repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM almalinux:9
 
-COPY ./signnode.repo /etc/yum.repos.d/signnode.repo
-RUN dnf upgrade -y && dnf install -y --enablerepo="signnode" \
+COPY signnode.repo /etc/yum.repos.d/signnode.repo
+RUN dnf upgrade -y && dnf install -y --enablerepo="buildsystem" \
         rpm-sign pinentry keyrings-filesystem ubu-keyring debian-keyring raspbian-keyring git && \
     dnf clean all
 

--- a/signnode.repo
+++ b/signnode.repo
@@ -1,5 +1,5 @@
-[signnode]
+[buildsystem]
 baseurl = https://repo.almalinux.org/build_system/9/$basearch/
 enabled = 0
 gpgcheck = 0
-name = AlmaLinux - 9 - SignNode
+name = AlmaLinux - 9 - BuildSystem


### PR DESCRIPTION
There's a link to the BuildSystem repo, so name it accordingly.