### PR TITLE
Rename signnode.repo -> extra-repos.repo and enable 'buildsystem'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 FROM almalinux:9
 
-COPY signnode.repo /etc/yum.repos.d/signnode.repo
-RUN dnf upgrade -y && dnf install -y --enablerepo="buildsystem" \
-        rpm-sign pinentry keyrings-filesystem ubu-keyring debian-keyring raspbian-keyring git && \
-    dnf clean all
+COPY extra-repos.repo /etc/yum.repos.d/extra-repos.repo
+RUN <<EOT bash
+  set -ex
+  dnf upgrade -y
+  dnf install -y rpm-sign pinentry keyrings-filesystem ubu-keyring debian-keyring raspbian-keyring git
+  dnf clean all
+EOT
 
 WORKDIR /sign-node
 COPY requirements.* .
-RUN python3 -m ensurepip && pip3 install -r requirements.devel.txt && rm requirements.*
+RUN <<EOT bash
+  set -ex
+  python3 -m ensurepip
+  pip3 install -r requirements.devel.txt
+  rm requirements.*
+EOT
 
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /

--- a/extra-repos.repo
+++ b/extra-repos.repo
@@ -1,5 +1,5 @@
 [buildsystem]
 baseurl = https://repo.almalinux.org/build_system/9/$basearch/
-enabled = 0
+enabled = 1
 gpgcheck = 0
-name = AlmaLinux - 9 - BuildSystem
+name = AlmaLinux 9 - BuildSystem


### PR DESCRIPTION
Also, unfold Dockerfile RUN commands for readability using heredoc.