### PR TITLE
Fix the "Pull Request Checks" workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,22 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check the PR title and description
-        run: |
-          errors=
+      - name: Check the PR title
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^.{1,72}$'
+          excludeTitle: 'false'
+          excludeDescription: 'true'
+          error: 'The maximum line length of 72 characters is exceeded.'
 
-          if grep -qE '^.{73,}$' <<< "${{ github.event.pull_request.title }}"; then
-            printf "ERROR: The PR title is longer than 72 characters:\n"
-            printf "  > ${{ github.event.pull_request.title }}\n"
-            errors=true
-          fi
-
-          issue_regex='(Resolves|Fixes):? +(https:\/\/github.com\/)?AlmaLinux\/build-system(\/issues\/|#)[0-9]+'
-          if ! grep -qE "$issue_regex" <<< "${{ github.event.pull_request.body }}"; then
-            printf "ERROR: You need at least one \"Resolves|Fixes: <issue link>\" line.\n"
-            errors=true
-          fi
-
-          if [[ $errors == true ]]; then
-            exit 2
-          fi
+      - name: Check the PR description
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '(Resolves|Fixes):? +(https:\/\/github.com\/)?AlmaLinux\/build-system(\/issues\/|#)[0-9]+'
+          error: 'You need at least one "Resolves|Fixes: <issue link>" line.'


### PR DESCRIPTION
The current implementation fails if the PR description contains quotes. This commit uses 'gsactions/commit-message-checker' for verification.

Resolves: AlmaLinux/build-system/issues/286